### PR TITLE
March updates getting ready for conference

### DIFF
--- a/src/Amendment.Client.Repository/Amendment.Client.Repository.csproj
+++ b/src/Amendment.Client.Repository/Amendment.Client.Repository.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\Amendment.Shared\Amendment.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Amendment.Client/Amendment.Client.csproj
+++ b/src/Amendment.Client/Amendment.Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -12,20 +12,20 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="Blazorise.Bootstrap5" Version="1.5.3" />
-    <PackageReference Include="Blazorise.Components" Version="1.5.3" />
-    <PackageReference Include="Blazorise.FluentValidation" Version="1.5.3" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.5.3" />
-    <PackageReference Include="Blazorise.Markdown" Version="1.5.3" />
-    <PackageReference Include="Blazorise.Snackbar" Version="1.5.3" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
-    <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="1.7.5" />
+    <PackageReference Include="Blazorise.Components" Version="1.7.5" />
+    <PackageReference Include="Blazorise.FluentValidation" Version="1.7.5" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.5" />
+    <PackageReference Include="Blazorise.Markdown" Version="1.7.5" />
+    <PackageReference Include="Blazorise.Snackbar" Version="1.7.5" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageReference Include="Markdig" Version="0.40.0" />
     <PackageReference Include="Toolbelt.Blazor.HttpClientInterceptor" Version="10.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Amendment.Client.Repository\Amendment.Client.Repository.csproj" />

--- a/src/Amendment.Model/Amendment.Model.csproj
+++ b/src/Amendment.Model/Amendment.Model.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>latest</LangVersion>
@@ -9,8 +9,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="Lorem.Universal.NET" Version="4.0.80" />
-    <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="Markdig" Version="0.40.0" />
   </ItemGroup>
 </Project>

--- a/src/Amendment.Repository/Amendment.Repository.csproj
+++ b/src/Amendment.Repository/Amendment.Repository.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>latest</LangVersion>
@@ -9,14 +9,14 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Amendment.Model\Amendment.Model.csproj" />

--- a/src/Amendment.Server.Handlers/Amendment.Server.Mediator.csproj
+++ b/src/Amendment.Server.Handlers/Amendment.Server.Mediator.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mapster" Version="7.4.1-pre01" />
-    <PackageReference Include="MediatR" Version="12.3.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Amendment.Service\Amendment.Service.csproj" />

--- a/src/Amendment.Server/Amendment.Server.csproj
+++ b/src/Amendment.Server/Amendment.Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>479600b8-1aaa-4248-a8ee-cb850ba04410</UserSecretsId>
@@ -8,26 +8,26 @@
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="8.0.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="FluentValidation" Version="11.9.2" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
+    <PackageReference Include="Autofac" Version="8.2.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="Mapster" Version="7.4.1-pre01" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.7" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="9.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Amendment.Server.Handlers\Amendment.Server.Mediator.csproj" />

--- a/src/Amendment.Server/Dockerfile
+++ b/src/Amendment.Server/Dockerfile
@@ -1,12 +1,12 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["src/Amendment.Server/Amendment.Server.csproj", "src/Amendment.Server/"]

--- a/src/Amendment.Service/Amendment.Service.csproj
+++ b/src/Amendment.Service/Amendment.Service.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.7.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Amendment.Shared/Amendment.Shared.csproj
+++ b/src/Amendment.Shared/Amendment.Shared.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.9.2" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
   </ItemGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/test/Amendment.Client.Repository.Tests/Amendment.Client.Repository.Tests.csproj
+++ b/test/Amendment.Client.Repository.Tests/Amendment.Client.Repository.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Amendment.Server.Tests/Amendment.Server.Tests.csproj
+++ b/test/Amendment.Server.Tests/Amendment.Server.Tests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amendment.Server\Amendment.Server.csproj" />


### PR DESCRIPTION
This pull request includes several updates across multiple project files to upgrade the .NET target framework and various package dependencies. The primary changes involve updating the target framework from `net8.0` to `net9.0` and upgrading multiple package versions to their latest releases.

Framework and package updates:

* [`src/Amendment.Client.Repository/Amendment.Client.Repository.csproj`](diffhunk://#diff-c8d417c74d63b445077ecabf73aeb8902f9c15f0b41047ba4d00b79716ea6560L3-R11): Updated target framework to `net9.0` and upgraded `Microsoft.AspNetCore.SignalR.Client` to version `9.0.3`.
* [`src/Amendment.Client/Amendment.Client.csproj`](diffhunk://#diff-a84266524eac12bf80de12ab9ff1ccb6198ae6464f963ed80a0329806a57cd45L3-R3): Updated target framework to `net9.0` and upgraded several packages including `Blazorise` packages, `FluentValidation`, and `Microsoft.AspNetCore` packages to their latest versions. [[1]](diffhunk://#diff-a84266524eac12bf80de12ab9ff1ccb6198ae6464f963ed80a0329806a57cd45L3-R3) [[2]](diffhunk://#diff-a84266524eac12bf80de12ab9ff1ccb6198ae6464f963ed80a0329806a57cd45L15-R28)
* [`src/Amendment.Model/Amendment.Model.csproj`](diffhunk://#diff-a4918f36581fa72c3a912f9872b7ed01f3fa951c835461e63c8e90d27f284c39L3-R3): Updated target framework to `net9.0` and upgraded `AutoMapper` and `Markdig` packages. [[1]](diffhunk://#diff-a4918f36581fa72c3a912f9872b7ed01f3fa951c835461e63c8e90d27f284c39L3-R3) [[2]](diffhunk://#diff-a4918f36581fa72c3a912f9872b7ed01f3fa951c835461e63c8e90d27f284c39L12-R14)
* [`src/Amendment.Repository/Amendment.Repository.csproj`](diffhunk://#diff-cb75ed237ee4bdb59a37ef8a9790ebfed37b02658f935d7300c692de6f156166L3-R3): Updated target framework to `net9.0` and upgraded `Npgsql.EntityFrameworkCore.PostgreSQL` and `Microsoft.EntityFrameworkCore` packages. [[1]](diffhunk://#diff-cb75ed237ee4bdb59a37ef8a9790ebfed37b02658f935d7300c692de6f156166L3-R3) [[2]](diffhunk://#diff-cb75ed237ee4bdb59a37ef8a9790ebfed37b02658f935d7300c692de6f156166L12-R19)
* [`src/Amendment.Server/Amendment.Server.csproj`](diffhunk://#diff-2461369f5614e9b7a16b2ac770b8f60f8f8a4414aa698b9c72a89e1eda8709b9L3-R30): Updated target framework to `net9.0` and upgraded multiple packages including `Autofac`, `FluentValidation`, `Microsoft.AspNetCore`, and `Swashbuckle.AspNetCore`.

Dockerfile update:

* [`src/Amendment.Server/Dockerfile`](diffhunk://#diff-3428310e58adaa60a506420a77bc4a0b7a9d8957ea6b64504990f77125875425L3-R9): Updated base and build images from `dotnet/aspnet:8.0` and `dotnet/sdk:8.0` to `dotnet/aspnet:9.0` and `dotnet/sdk:9.0`, respectively.

Test project updates:

* [`test/Amendment.Client.Repository.Tests/Amendment.Client.Repository.Tests.csproj`](diffhunk://#diff-8d4c44b2ee1f041033b53cd7179888d1e33a61994c2dd7b73b9f68ff3e7abf7bL3-R16): Updated target framework to `net9.0` and upgraded testing packages including `Microsoft.NET.Test.Sdk`, `NSubstitute`, `xunit`, and `coverlet.collector`.
* [`test/Amendment.Server.Tests/Amendment.Server.Tests.csproj`](diffhunk://#diff-f85d156fb2272b2b8075befd2a9fcf88bd8fc3f2d6894e4ffa5a50242142f244L3-R19): Updated target framework to `net9.0` and upgraded testing packages including `Microsoft.NET.Test.Sdk`, `xunit`, `coverlet.collector`, and `Microsoft.AspNetCore.Mvc.Testing`.